### PR TITLE
Refresh with latest SOFA + MSVC compatilibity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ else()
     set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 endif ()
 
-find_package(SofaFramework REQUIRED)
-find_package(SofaBase REQUIRED) # Dependency to SofaBaseVisual
+find_package(Sofa.Config REQUIRED)
+find_package(Sofa.Component.Visual REQUIRED)
 find_package(Qt5 COMPONENTS Gui REQUIRED) # Dependency to Qt5::Gui
 find_package(GLEW QUIET REQUIRED)
 
@@ -34,7 +34,7 @@ set(HEADER_FILES
 
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES} ${HEADER_FILES})
 
-target_link_libraries(${PROJECT_NAME} PUBLIC Qt5::Gui SofaBaseVisual)
+target_link_libraries(${PROJECT_NAME} PUBLIC Qt5::Gui Sofa.Component.Visual)
 target_link_libraries(${PROJECT_NAME} PRIVATE GLEW::GLEW)
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,8 @@ endif ()
 find_package(Sofa.Config REQUIRED)
 find_package(Sofa.Component.Visual REQUIRED)
 find_package(Qt5 COMPONENTS Gui REQUIRED) # Dependency to Qt5::Gui
-find_package(OpenGL QUIET REQUIRED)
-find_package(GLEW QUIET REQUIRED)
+find_package(OpenGL REQUIRED)
+find_package(GLEW REQUIRED)
 
 
 set(SOURCE_FILES
@@ -29,6 +29,7 @@ set(SOURCE_FILES
 )
 
 set(HEADER_FILES
+    src/SofaOffscreenCamera/config.h.in
     src/SofaOffscreenCamera/OffscreenCamera.h
     src/SofaOffscreenCamera/GlewProxy.h
     src/SofaOffscreenCamera/QtDrawToolGL.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,9 @@ endif ()
 find_package(Sofa.Config REQUIRED)
 find_package(Sofa.Component.Visual REQUIRED)
 find_package(Qt5 COMPONENTS Gui REQUIRED) # Dependency to Qt5::Gui
+find_package(OpenGL QUIET REQUIRED)
 find_package(GLEW QUIET REQUIRED)
+
 
 set(SOURCE_FILES
     src/SofaOffscreenCamera/init.cpp
@@ -35,7 +37,7 @@ set(HEADER_FILES
 add_library(${PROJECT_NAME} SHARED ${SOURCE_FILES} ${HEADER_FILES})
 
 target_link_libraries(${PROJECT_NAME} PUBLIC Qt5::Gui Sofa.Component.Visual)
-target_link_libraries(${PROJECT_NAME} PRIVATE GLEW::GLEW)
+target_link_libraries(${PROJECT_NAME} PRIVATE OpenGL::GL GLEW::GLEW)
 target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_17)
 
 # Create package Config, Version & Target files.

--- a/SofaOffscreenCameraConfig.cmake.in
+++ b/SofaOffscreenCameraConfig.cmake.in
@@ -1,10 +1,9 @@
 @PACKAGE_GUARD@
 @PACKAGE_INIT@
 
-find_package(SofaBase QUIET REQUIRED)
-
-find_package(SofaBase REQUIRED) # Dependency to SofaBaseVisual
-find_package(Qt5 COMPONENTS Gui REQUIRED) # Dependency to Qt5::Gui
+find_package(Sofa.Config QUIET REQUIRED)
+find_package(Sofa.Component.Visual QUIET REQUIRED) # Dependency to SofaBaseVisual
+find_package(Qt5 COMPONENTS Gui QUIET REQUIRED) # Dependency to Qt5::Gui
 
 if(NOT TARGET @PROJECT_NAME@)
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/SofaOffscreenCameraConfig.cmake.in
+++ b/SofaOffscreenCameraConfig.cmake.in
@@ -4,6 +4,8 @@
 find_package(Sofa.Config QUIET REQUIRED)
 find_package(Sofa.Component.Visual QUIET REQUIRED) # Dependency to SofaBaseVisual
 find_package(Qt5 COMPONENTS Gui QUIET REQUIRED) # Dependency to Qt5::Gui
+find_package(OpenGL QUIET REQUIRED)
+find_package(GLEW QUIET REQUIRED)
 
 if(NOT TARGET @PROJECT_NAME@)
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -20,7 +20,7 @@ SP3_add_python_module (
 #    DESTINATION  OffscreenCamera
     SOURCES      ${SOURCE_FILES}
     HEADERS      ${HEADER_FILES}
-    DEPENDS      SofaOffscreenCamera SofaPython3::Bindings
+    DEPENDS      SofaOffscreenCamera SofaPython3::Bindings.Sofa
 )
 message(STATUS "Python support:
     Version: ${Python_VERSION}

--- a/bindings/src/SofaOffscreenCamera/Bindings/Binding_OffscreenCamera.cpp
+++ b/bindings/src/SofaOffscreenCamera/Bindings/Binding_OffscreenCamera.cpp
@@ -6,7 +6,7 @@ namespace py = pybind11;
 template <typename T> using py_shared_ptr = sofapython3::py_shared_ptr<T>;
 
 void add_offscreen_camera_to_module(pybind11::module &m) {
-    using BaseCamera =  sofa::component::visualmodel::BaseCamera;
+    using BaseCamera =  sofa::component::visual::BaseCamera;
 
     py::class_< OffscreenCamera, BaseCamera, py_shared_ptr<OffscreenCamera> > c(m, "OffscreenCamera");
     c.def(py::init());

--- a/src/SofaOffscreenCamera/OffscreenCamera.cpp
+++ b/src/SofaOffscreenCamera/OffscreenCamera.cpp
@@ -53,7 +53,7 @@ OffscreenCamera::OffscreenCamera()
     false /*is_read_only*/ ))
 {
     if (! QCoreApplication::instance()) {
-        // In case we are not inside a Qt application (such as with SofaQt),
+        // In case we are !inside a Qt application (such as with SofaQt),
         // and a previous OffscreenCamera hasn't created it
         static int argc = 1;
         static char * arg0 = strdup("Offscreen");
@@ -93,7 +93,7 @@ void OffscreenCamera::init() {
         msg_info() << "An OpenGl context already existed. Let's share it.";
     }
 
-    if (not p_context->create()) {
+    if (!p_context->create()) {
         msg_error() << "Failed to create the OpenGL context";
         return;
     }
@@ -102,7 +102,7 @@ void OffscreenCamera::init() {
     Base::init();
     computeZ();
 
-    if (not p_context->makeCurrent(p_surface)) {
+    if (!p_context->makeCurrent(p_surface)) {
         msg_error() << "Failed to swap the surface of OpenGL context.";
         return;
     }
@@ -111,7 +111,7 @@ void OffscreenCamera::init() {
     p_framebuffer = new QOpenGLFramebufferObject(width, height, GL_TEXTURE_2D);
     msg_info() << "Framebuffer created.";
 
-    if (not p_framebuffer->bind()) {
+    if (!p_framebuffer->bind()) {
         msg_error() << "Failed to bind the OpenGL framebuffer.";
     }
 
@@ -139,11 +139,11 @@ QImage OffscreenCamera::grab_frame() {
     }
     auto * previous_context = QOpenGLContext::currentContext();
     auto * previous_surface = previous_context ? previous_context->surface() : nullptr;
-    if (not p_context->makeCurrent(p_surface)) {
+    if (!p_context->makeCurrent(p_surface)) {
         throw std::runtime_error("Failed to swap the surface of OpenGL context.");
     }
 
-    if (not p_framebuffer->bind()) {
+    if (!p_framebuffer->bind()) {
         throw std::runtime_error("Failed to bind the OpenGL framebuffer.");
     }
 
@@ -161,7 +161,7 @@ QImage OffscreenCamera::grab_frame() {
     glMultMatrixd(projectionMatrix);
 
     // We recompute the MVM since sofa doesn't do it unless the "look-at" changed. Hence,
-    // in the case the camera position moved, but not the "look-at", the orientation will
+    // in the case the camera position moved, but !the "look-at", the orientation will
     // be wrong.
     const auto currentPos = p_position.getValue();
     currentLookAt = p_lookAt.getValue();
@@ -232,7 +232,7 @@ QImage OffscreenCamera::grab_frame() {
         previous_context->makeCurrent(previous_surface);
     }
 
-    if (not p_framebuffer->release()) {
+    if (!p_framebuffer->release()) {
         throw std::runtime_error("Failed to release the OpenGL framebuffer.");
     }
 

--- a/src/SofaOffscreenCamera/OffscreenCamera.h
+++ b/src/SofaOffscreenCamera/OffscreenCamera.h
@@ -6,14 +6,14 @@
 #include <QOffscreenSurface>
 #include <QOpenGLContext>
 
-#include <SofaBaseVisual/BaseCamera.h>
+#include <sofa/component/visual/BaseCamera.h>
 
-class OffscreenCamera : public sofa::component::visualmodel::BaseCamera {
-    using Base = sofa::component::visualmodel::BaseCamera;
+class OffscreenCamera : public sofa::component::visual::BaseCamera {
+    using Base = sofa::component::visual::BaseCamera;
     template <typename T> using Data = sofa::core::objectmodel::Data<T>;
 
 public:
-    SOFA_CLASS(OffscreenCamera, sofa::component::visualmodel::BaseCamera);
+    SOFA_CLASS(OffscreenCamera, sofa::component::visual::BaseCamera);
 
     /**
      * Main constructor of the camera

--- a/src/SofaOffscreenCamera/OffscreenCamera.h
+++ b/src/SofaOffscreenCamera/OffscreenCamera.h
@@ -1,3 +1,4 @@
+#include <SofaOffscreenCamera/config.h>
 #include <memory>
 
 #include <QGuiApplication>
@@ -8,7 +9,7 @@
 
 #include <sofa/component/visual/BaseCamera.h>
 
-class OffscreenCamera : public sofa::component::visual::BaseCamera {
+class SOFA_SOFAOFFSCREENCAMERA_API OffscreenCamera : public sofa::component::visual::BaseCamera {
     using Base = sofa::component::visual::BaseCamera;
     template <typename T> using Data = sofa::core::objectmodel::Data<T>;
 

--- a/src/SofaOffscreenCamera/QtDrawToolGL.h
+++ b/src/SofaOffscreenCamera/QtDrawToolGL.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <sofa/core/config.h>
+#include <SofaOffscreenCamera/config.h>
+
 #include <sofa/helper/visual/DrawTool.h>
 #include <sofa/type/Quat.h>
 #include <sofa/type/RGBAColor.h>
@@ -9,7 +11,7 @@
 #include <sofa/type/vector.h>
 
 namespace sofa::helper::visual {
-class SOFA_CORE_API QtDrawToolGL : public DrawTool {
+class SOFA_SOFAOFFSCREENCAMERA_API QtDrawToolGL : public DrawTool {
 public:
     using Base = DrawTool;
     using RGBAColor = Base::RGBAColor;

--- a/src/SofaOffscreenCamera/QtDrawToolGL.h
+++ b/src/SofaOffscreenCamera/QtDrawToolGL.h
@@ -14,7 +14,7 @@ public:
     using Base = DrawTool;
     using RGBAColor = Base::RGBAColor;
     using Vec3f = Base::Vec3f;
-    using Vector3 = Base::Vector3;
+    using Vector3 = Base::Vec3;
     using Vec3i = Base::Vec3i;
     using Vec2i = Base::Vec2i;
     using Quaternion = Base::Quaternion;

--- a/src/SofaOffscreenCamera/config.h.in
+++ b/src/SofaOffscreenCamera/config.h.in
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <sofa/config.h>
+#include <sofa/config/sharedlibrary_defines.h>
+
+#define SOFAOFFSCREENCAMERA_VERSION @PROJECT_VERSION@
+
+#ifdef SOFA_BUILD_SOFAOFFSCREENCAMERA
+#  define SOFA_TARGET @PROJECT_NAME@
+#  define SOFA_SOFAOFFSCREENCAMERA_API SOFA_EXPORT_DYNAMIC_LIBRARY
+#else
+#  define SOFA_SOFAOFFSCREENCAMERA_API SOFA_IMPORT_DYNAMIC_LIBRARY
+#endif


### PR DESCRIPTION
- _API macros (+ config.h.in)
- `not` not supported on msvc apparently
- usage of sofa.component.visual
- some link shenanigan for msvc (need opengl)